### PR TITLE
Only build galera, don't do any tests

### DIFF
--- a/packages/galera/packaging
+++ b/packages/galera/packaging
@@ -24,7 +24,7 @@ PATH=$PATH:/var/vcap/packages/python/bin
 # Go Agent cannot handle more than 10MB output, so trim it
 #
 set +e
-/var/vcap/packages/scons/bin/scons > build.out 2> build.err
+/var/vcap/packages/scons/bin/scons tests=0 > build.out 2> build.err
 BUILD_EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
I have no idea why our working branch is `hcf-1162-mysql-bootstrap-fix`, but somebody else will have to resolve that one.

This just turns off building tests when packaging galera.  🚬 passes fine locally, so I assume mysql is working enough to have a good cloud controller.

Currently attempting to make an upstream PR.